### PR TITLE
refactor(chat): reorganize imports and improve file structure

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,5 +3,5 @@ node_modules
 build
 dist 
 src/components/
-src/services/auth/index.ts
-@types/next-auth.d.ts
+src/services
+@types

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { defaultErrorMessage } from './config'
 import { logChatError } from './logger'
 import { processChatAndSaveMessages } from './services/chat-processor'
+import { errorHandler } from './utils/error-handler'
 
 const schema = z.object({
   messages: z.array(
@@ -75,20 +76,4 @@ export async function POST(req: NextRequest) {
       { status: 500 },
     )
   }
-}
-
-export function errorHandler(error: unknown) {
-  if (error === null) {
-    return 'unknown error'
-  }
-
-  if (typeof error === 'string') {
-    return error
-  }
-
-  if (error instanceof Error) {
-    return error.message
-  }
-
-  return JSON.stringify(error)
 }

--- a/src/app/api/chat/services/chat-operations.ts
+++ b/src/app/api/chat/services/chat-operations.ts
@@ -6,8 +6,8 @@ import { StreamTextResult } from 'ai'
 
 import { prisma } from '@/services/database/prisma'
 
-import { errorHandler } from '../route'
 import { weatherTool } from '../tools/weather'
+import { errorHandler } from '../utils/error-handler'
 import { processStreamResult } from '../utils/message-parts'
 
 type AllTools = {

--- a/src/app/api/chat/services/chat-processor.ts
+++ b/src/app/api/chat/services/chat-processor.ts
@@ -1,8 +1,8 @@
 import { Message, StreamTextResult } from 'ai'
 
 import { generateSystemPrompt } from '../prompts'
-import { errorHandler } from '../route'
 import { weatherTool } from '../tools/weather'
+import { errorHandler } from '../utils/error-handler'
 import {
   processToolInvocations,
   validateMessages,

--- a/src/app/api/chat/utils/error-handler.ts
+++ b/src/app/api/chat/utils/error-handler.ts
@@ -1,0 +1,15 @@
+export function errorHandler(error: unknown): string {
+  if (error === null) {
+    return 'unknown error'
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return JSON.stringify(error)
+}

--- a/src/app/api/login/actions/_create-user.ts
+++ b/src/app/api/login/actions/_create-user.ts
@@ -6,13 +6,13 @@ import { createUserAndSendMagicLink } from './create-user'
 
 export type FormState =
   | {
-    errors?: {
-      name?: string[]
-      email?: string[]
-      avatar?: string[]
+      errors?: {
+        name?: string[]
+        email?: string[]
+        avatar?: string[]
+      }
+      message?: string
     }
-    message?: string
-  }
   | undefined
 
 export async function createUser(state: FormState, formData: FormData) {

--- a/src/app/api/todo/route.ts
+++ b/src/app/api/todo/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: NextRequest) {
 
   const { todo, error: createTodoError } = await createTodoAction({
     title,
-    id: session!.user.id,
+    userId: session!.user.id,
   })
 
   if (createTodoError) {

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -33,21 +33,21 @@ type ActionType = typeof actionTypes
 
 type Action =
   | {
-    type: ActionType['ADD_TOAST']
-    toast: ToasterToast
-  }
+      type: ActionType['ADD_TOAST']
+      toast: ToasterToast
+    }
   | {
-    type: ActionType['UPDATE_TOAST']
-    toast: Partial<ToasterToast>
-  }
+      type: ActionType['UPDATE_TOAST']
+      toast: Partial<ToasterToast>
+    }
   | {
-    type: ActionType['DISMISS_TOAST']
-    toastId?: ToasterToast['id']
-  }
+      type: ActionType['DISMISS_TOAST']
+      toastId?: ToasterToast['id']
+    }
   | {
-    type: ActionType['REMOVE_TOAST']
-    toastId?: ToasterToast['id']
-  }
+      type: ActionType['REMOVE_TOAST']
+      toastId?: ToasterToast['id']
+    }
 
 interface State {
   toasts: ToasterToast[]
@@ -105,9 +105,9 @@ export const reducer = (state: State, action: Action): State => {
         toasts: state.toasts.map((t) =>
           t.id === toastId || toastId === undefined
             ? {
-              ...t,
-              open: false,
-            }
+                ...t,
+                open: false,
+              }
             : t,
         ),
       }


### PR DESCRIPTION
- Update .eslintignore to include services and types directories
- Move errorHandler function to utils for better organization
- Adjust imports in chat files to reflect new structure
- Improve code readability by formatting action types in toast hook